### PR TITLE
This is how you collapse a government by turning a 1 to a 0

### DIFF
--- a/src/components/portfolioViews/tile/TileItem.astro
+++ b/src/components/portfolioViews/tile/TileItem.astro
@@ -115,7 +115,7 @@ const overlayColor = colord(
   @media (any-hover: none) {
     .tile-hover-panel {
       transform: scale(1);
-      opacity: 1;
+      opacity: 0;
     }
   }
 </style>


### PR DESCRIPTION
I literally turned a 1 to a 0. The opacity in the tile layout option was set to 1 when there is no hover mechanic detected causing all the containers to show their hover state by default. Now it will not show the hover state by default if there is no hover mechanic detected.

This was tested on Chrome and Firefox